### PR TITLE
Create github action for publishing to pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build-n-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v3.3.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.x"
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1.6.4
+        with:
+          # Password is set in GitHub UI to an API secret for pypi
+          user: __token__
+          password: ${{ secrets.PYPI_API_KEY }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,9 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "xpystac"
-author = "Julia Signell"
-author-email = "jsignell@azavea.com"
+authors = [
+    {name = "Julia Signell", email = "jsignell@element84.com"}
+]
 classifiers = [ "License :: OSI Approved :: MIT License",]
 dependencies = [
     "xarray",


### PR DESCRIPTION
How to release a new version of `xpystac` to PyPi

## Releasing

1. Update version in source code: https://github.com/jsignell/xpystac/blob/main/xpystac/__init__.py
2. Created and push a tag on `main` branch:
  
  ```
  git tag -a 0.0.1 -m "Release 0.0.1"
  git push --tags
  ```

3. [Create a new release using the GitHub UI](https://github.com/jsignell/xpystac/releases/new)
    - the tag should be a version number, like `0.0.1`
    - choose the target from "recent commits", and select the most recent commit on `main`
4. Once this release is created, a GitHub Actions build will automatically start. That build publishes a release to PyPi. You can access logs for this build on the "Actions" tab in GitHub.