### PR TITLE
Fix opening STAC Assets with xarray:open_kwargs engine field

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,3 +49,9 @@ def simple_zarr() -> pystac.Asset:
         catalog = pystac_client.Client.open(STAC_URLS["PLANETARY-COMPUTER"])
         collection = catalog.get_collection("daymet-daily-hi")
         return collection.assets["zarr-abfs"]
+
+
+@pytest.fixture(scope="module")
+def complex_zarr(simple_zarr) -> pystac.Asset:
+    simple_zarr.extra_fields["xarray:open_kwargs"]["engine"] = "zarr"
+    return simple_zarr

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -30,4 +30,9 @@ def test_to_xarray_reference_file(simple_reference_file):
 
 def test_to_xarray_zarr(simple_zarr):
     ds = to_xarray(simple_zarr)
-    ds
+    assert ds
+
+
+def test_to_xarray_zarr_with_open_kwargs_engine(complex_zarr):
+    ds = to_xarray(complex_zarr)
+    assert ds

--- a/xpystac/core.py
+++ b/xpystac/core.py
@@ -55,14 +55,14 @@ def _(obj: pystac.Asset, **kwargs) -> xarray.Dataset:
         default_kwargs = {"engine": "zarr", "consolidated": False, "chunks": {}}
         return xarray.open_dataset(mapper, **default_kwargs, **open_kwargs, **kwargs)
 
-    if obj.media_type == pystac.MediaType.COG:
-        _import_optional_dependency("rioxarray")
-        default_kwargs = {"engine": "rasterio"}
-    elif obj.media_type == "application/vnd+zarr":
-        _import_optional_dependency("zarr")
-        default_kwargs = {"engine": "zarr"}
-    else:
-        default_kwargs = {}
+    default_kwargs = {}
+    if open_kwargs.get("engine") is None:
+        if obj.media_type == pystac.MediaType.COG:
+            _import_optional_dependency("rioxarray")
+            default_kwargs["engine"] = "rasterio"
+        elif obj.media_type == "application/vnd+zarr":
+            _import_optional_dependency("zarr")
+            default_kwargs["engine"] = "zarr"
 
     ds = xarray.open_dataset(obj.href, **default_kwargs, **open_kwargs, **kwargs)
     return ds

--- a/xpystac/core.py
+++ b/xpystac/core.py
@@ -55,14 +55,14 @@ def _(obj: pystac.Asset, **kwargs) -> xarray.Dataset:
         default_kwargs = {"engine": "zarr", "consolidated": False, "chunks": {}}
         return xarray.open_dataset(mapper, **default_kwargs, **open_kwargs, **kwargs)
 
-    default_kwargs = {}
-    if open_kwargs.get("engine") is None:
-        if obj.media_type == pystac.MediaType.COG:
-            _import_optional_dependency("rioxarray")
-            default_kwargs["engine"] = "rasterio"
-        elif obj.media_type == "application/vnd+zarr":
-            _import_optional_dependency("zarr")
-            default_kwargs["engine"] = "zarr"
+    if obj.media_type == pystac.MediaType.COG:
+        _import_optional_dependency("rioxarray")
+        default_kwargs = {"engine": "rasterio"}
+    elif obj.media_type == "application/vnd+zarr":
+        _import_optional_dependency("zarr")
+        default_kwargs = {"engine": "zarr"}
+    else:
+        default_kwargs = {}
 
-    ds = xarray.open_dataset(obj.href, **default_kwargs, **open_kwargs, **kwargs)
+    ds = xarray.open_dataset(obj.href, **{**default_kwargs, **open_kwargs, **kwargs})
     return ds


### PR DESCRIPTION
Update the kwargs merging logic to have the 'engine' keyword argument from `default_kwarg` override the one set in the `open_kwargs` dict. Included a regression unit test that extends the existing simple_zarr test to ensure that the fix for duplicate keys works.

Note that the `xarray:open_kwargs` field is a part of the [`xarray-assets`](https://github.com/stac-extensions/xarray-assets/tree/v1.0.0) STAC extension (in Proposal stage), xref #16

Fixes #17