### PR TITLE
Implement zarr-extension handling

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -127,6 +127,24 @@ def test_to_xarray_zarr_with_open_kwargs_engine():
     to_xarray(zarr_asset)
 
 
+@requires_planetary_computer
+def test_to_xarray_zarr_with_zarr_extension():
+    import planetary_computer as pc
+
+    catalog = pystac_client.Client.open(
+        STAC_URLS["PLANETARY-COMPUTER"], modifier=pc.sign_inplace
+    )
+    collection = catalog.get_collection("daymet-daily-hi")
+    assert collection is not None
+    zarr_asset = collection.assets["zarr-abfs"]
+
+    # pop off the xarray-assets extension fields
+    zarr_asset.extra_fields.pop("xarray:open_kwargs")
+    zarr_asset.extra_fields["zarr:consolidated"] = True
+
+    to_xarray(zarr_asset)
+
+
 @pytest.mark.skip(reason="not yet supported with kerchunk >=0.2.8")
 def test_to_xarray_with_item_collection_with_kerchunk_attrs_in_data_cube(
     data_cube_kerchunk,

--- a/xpystac/core.py
+++ b/xpystac/core.py
@@ -182,8 +182,6 @@ def _(
             zarr_kwargs["consolidated"] = obj.extra_fields["zarr:consolidated"]
         if "zarr:zarr_format" in obj.extra_fields:
             zarr_kwargs["zarr_format"] = obj.extra_fields["zarr:zarr_format"]
-            if zarr_kwargs["zarr_format"] == 3:
-                raise ValueError("Zarr v3 is not supported by xpystac")
 
         default_kwargs = {**default_kwargs, **zarr_kwargs, "engine": "zarr"}
 

--- a/xpystac/core.py
+++ b/xpystac/core.py
@@ -175,9 +175,17 @@ def _(
     if obj.media_type == pystac.MediaType.COG:
         _import_optional_dependency("rioxarray")
         default_kwargs = {**default_kwargs, "engine": "rasterio"}
-    elif obj.media_type == "application/vnd+zarr":
+    elif obj.media_type in ["application/vnd+zarr", "application/vnd.zarr"]:
         _import_optional_dependency("zarr")
-        default_kwargs = {**default_kwargs, "engine": "zarr"}
+        zarr_kwargs = {}
+        if "zarr:consolidated" in obj.extra_fields:
+            zarr_kwargs["consolidated"] = obj.extra_fields["zarr:consolidated"]
+        if "zarr:zarr_format" in obj.extra_fields:
+            zarr_kwargs["zarr_format"] = obj.extra_fields["zarr:zarr_format"]
+            if zarr_kwargs["zarr_format"] == 3:
+                raise ValueError("Zarr v3 is not supported by xpystac")
+
+        default_kwargs = {**default_kwargs, **zarr_kwargs, "engine": "zarr"}
 
     href = obj.href
     if patch_url is not None:


### PR DESCRIPTION
I published the first version of the Zarr STAC Extension yesterday, so now seemed like a good time to implement reading a collection with zarr extension metadata. 

~I'd like to also handle passing storage options to the xarray reader from the storage extension so this PR is still WIP.~